### PR TITLE
AccountPolicy: Fix applying Account_lockout_duration to Zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
   - Add schema descriptions for all properties and update README.
   - Added PowerShell Dsc Resource Help Files.
 
+### Fixed
+
+- AccountPolicy
+  - Fix applying Account_lockout_duration to zero
+    [Issue #140](https://github.com/dsccommunity/SecurityPolicyDsc/issues/140).
+
 ## [2.10.0.0] - 2019-09-19
 
 - Changes to SecurityPolicyDsc:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,17 @@
 
 - SecurityPolicyDsc:
   - Resolved custom Script Analyzer rules that was added to the test framework.
-  - Move change log to CHANGELOG.md.
+  - Moved change log to CHANGELOG.md.
   - Added support for more SDDL SID constants
     [Issue #126](https://github.com/dsccommunity/SecurityPolicyDsc/issues/126).
     - Added functions to convert identity to and from SDDL SID constants.
     - Changed Format-RestrictedRemoteSAM to use new function to create strings with additional SDDL SID constants.
     - Changed ConvertTo-CimRestrictedRemoteSam to use new function to accept more possible SDDL SID constants.
     - Changed ConvertTo-CimRestrictedRemoteSam to skip CimInstance creation if no valid Identity was found.
-  - Add schema descriptions for all properties and update README.
+  - Added schema descriptions for all properties and update README.
   - Added PowerShell Dsc Resource Help Files.
+- AccountPolicy:
+  - Improved and updated unit tests to Pester v4 format.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Fixed
 
-- AccountPolicy
+- AccountPolicy:
   - Fix applying Account_lockout_duration to zero
     [Issue #140](https://github.com/dsccommunity/SecurityPolicyDsc/issues/140).
 

--- a/Tests/Unit/MSFT_AccountPolicy.tests.ps1
+++ b/Tests/Unit/MSFT_AccountPolicy.tests.ps1
@@ -1,8 +1,6 @@
 $script:dscModuleName = 'SecurityPolicyDsc'
 $script:dscResourceName = 'MSFT_AccountPolicy'
 
-Write-Verbose -Message "PowerShell Version: $($PSVersionTable.PSVersion)" -Verbose
-
 function Invoke-TestSetup
 {
     try
@@ -182,7 +180,7 @@ try
         Describe 'Set-TargetResource' {
             BeforeAll {
                 Mock -CommandName Invoke-Secedit
-#                Mock -CommandName Out-File
+                Mock -CommandName Out-File -RemoveParameterType Encoding
                 Mock -CommandName Remove-Item
             }
 
@@ -207,13 +205,13 @@ try
                     Assert-MockCalled -CommandName Test-TargetResource `
                         -ParameterFilter { $Name -eq $resourceName } `
                          -Exactly -Times 1
-#                     Assert-MockCalled -CommandName Out-File `
-#                        -ParameterFilter {
-#                            $InputObject -contains "MaximumPasswordAge=$($testParameters.Maximum_Password_Age)" -and
-#                            $InputObject -contains "LockoutDuration=$($testParameters.Account_lockout_duration)" -and
-#                            $InputObject -contains "ClearTextPassword=1"
-#                        } `
-#                        -Exactly -Times 1
+                     Assert-MockCalled -CommandName Out-File `
+                        -ParameterFilter {
+                            $InputObject -contains "MaximumPasswordAge=$($testParameters.Maximum_Password_Age)" -and
+                            $InputObject -contains "LockoutDuration=$($testParameters.Account_lockout_duration)" -and
+                            $InputObject -contains "ClearTextPassword=1"
+                        } `
+                        -Exactly -Times 1
                     Assert-MockCalled -CommandName Invoke-Secedit -Exactly -Times 1
                     Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1
         }

--- a/Tests/Unit/MSFT_AccountPolicy.tests.ps1
+++ b/Tests/Unit/MSFT_AccountPolicy.tests.ps1
@@ -1,6 +1,8 @@
 $script:dscModuleName = 'SecurityPolicyDsc'
 $script:dscResourceName = 'MSFT_AccountPolicy'
 
+Write-Verbose -Message "PowerShell Version: $($PSVersionTable.PSVersion)" -Verbose
+
 function Invoke-TestSetup
 {
     try
@@ -30,7 +32,7 @@ try
 {
     InModuleScope 'MSFT_AccountPolicy' {
         Set-StrictMode -Version 1.0
-        
+
         $resourceName='AccountPolicy'
         $dscResourceInfo = Get-DscResource -Name AccountPolicy -Module SecurityPolicyDsc
         $testParameters = @{
@@ -50,22 +52,22 @@ try
                 }
 
                 It 'Should have the same count as property count' {
-                    $accountPolicyDataPropertyCount = $accountPolicyData.Count                    
+                    $accountPolicyDataPropertyCount = $accountPolicyData.Count
                     $accountPolicyDataPropertyCount | Should -Be $accountPolicyPropertyList.Name.Count
                 }
 
                 foreach ($name in $accountPolicyData.Keys)
                 {
-                    It "Should contain property name: $name" {                        
-                        $accountPolicyPropertyList.Name -contains $name | Should -BeTrue                        
+                    It "Should contain property name: $name" {
+                        $accountPolicyPropertyList.Name -contains $name | Should -BeTrue
                     }
                 }
-                
+
                 foreach ($option in $accountPolicyData.GetEnumerator())
                 {
                     Context "$($option.Name)"{
                         $options = $option.Value.Option
-                    
+
                         foreach ($entry in $options.GetEnumerator())
                         {
                             It "$($entry.Name) Should have string as Option type" {
@@ -87,7 +89,7 @@ try
                     [string[]]$testString = "MaxClockSkew=5"
                     [string]$addOptionResult = Add-PolicyOption -KerberosPolicies $testString
 
-                    $addOptionResult | Should Match '[Kerberos Policy]'    
+                    $addOptionResult | Should Match '[Kerberos Policy]'
                 }
             }
         }
@@ -180,10 +182,10 @@ try
         Describe 'Set-TargetResource' {
             BeforeAll {
                 Mock -CommandName Invoke-Secedit
-                Mock -CommandName Out-File
+#                Mock -CommandName Out-File
                 Mock -CommandName Remove-Item
             }
-            
+
             Context 'When successfully applying the account policy' {
                 BeforeAll {
                     Mock -CommandName Test-TargetResource `
@@ -197,7 +199,7 @@ try
                 It 'Should not throw' {
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                 }
-                
+
                 It 'Should call the expected mocks' {
                     Assert-MockCalled -CommandName Test-TargetResource `
                        -ParameterFilter { $Name -eq 'Test' } `
@@ -205,15 +207,15 @@ try
                     Assert-MockCalled -CommandName Test-TargetResource `
                         -ParameterFilter { $Name -eq $resourceName } `
                          -Exactly -Times 1
-                     Assert-MockCalled -CommandName Out-File `
-                        -ParameterFilter {
-                            $InputObject -contains "MaximumPasswordAge=$($testParameters.Maximum_Password_Age)" -and
-                            $InputObject -contains "LockoutDuration=$($testParameters.Account_lockout_duration)" -and
-                            $InputObject -contains "ClearTextPassword=1"
-                        } `
-                        -Exactly -Times 1 
-                    Assert-MockCalled -CommandName Invoke-Secedit -Exactly -Times 1                
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1                
+#                     Assert-MockCalled -CommandName Out-File `
+#                        -ParameterFilter {
+#                            $InputObject -contains "MaximumPasswordAge=$($testParameters.Maximum_Password_Age)" -and
+#                            $InputObject -contains "LockoutDuration=$($testParameters.Account_lockout_duration)" -and
+#                            $InputObject -contains "ClearTextPassword=1"
+#                        } `
+#                        -Exactly -Times 1
+                    Assert-MockCalled -CommandName Invoke-Secedit -Exactly -Times 1
+                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1
         }
 
                 Context 'When Maximum_password_age is Zero' {
@@ -235,9 +237,9 @@ try
                              -Exactly -Times 1
                         Assert-MockCalled -CommandName Out-File `
                             -ParameterFilter { $InputObject -contains 'MaximumPasswordAge=-1' } `
-                            -Exactly -Times 1 
-                        Assert-MockCalled -CommandName Invoke-Secedit -Exactly -Times 1                
-                        Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1                
+                            -Exactly -Times 1
+                        Assert-MockCalled -CommandName Invoke-Secedit -Exactly -Times 1
+                        Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1
                     }
                 }
 
@@ -260,9 +262,9 @@ try
                              -Exactly -Times 1
                         Assert-MockCalled -CommandName Out-File `
                             -ParameterFilter { $InputObject -contains 'LockoutDuration=-1' } `
-                            -Exactly -Times 1 
-                        Assert-MockCalled -CommandName Invoke-Secedit -Exactly -Times 1                
-                        Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1                
+                            -Exactly -Times 1
+                        Assert-MockCalled -CommandName Invoke-Secedit -Exactly -Times 1
+                        Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1
                     }
                 }
             }
@@ -295,7 +297,7 @@ try
                          -Exactly -Times 1
                     Assert-MockCalled -CommandName Out-File -Exactly -Times 1
                     Assert-MockCalled -CommandName Invoke-Secedit -Exactly -Times 1
-                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1                
+                    Assert-MockCalled -CommandName Remove-Item -Exactly -Times 1
                 }
             }
         }

--- a/Tests/Unit/MSFT_AccountPolicy.tests.ps1
+++ b/Tests/Unit/MSFT_AccountPolicy.tests.ps1
@@ -101,14 +101,25 @@ try
                 }
             }
 
-            Context 'Functional tests' {
+            Context 'When MaximumPasswordAge is -1' {
                 $securityPolicyMock = @{
                     'System Access' = @{ MaximumPasswordAge = -1}
                 }
                 Mock -CommandName 'Get-SecurityPolicy' -MockWith {$securityPolicyMock}
-                It 'Should return -1 for Max password age' {
+                It 'Should return 0' {
                     $getResult = Get-TargetResource -Name Test
                     $getResult.Maximum_Password_Age | Should Be 0
+                }
+            }
+
+            Context 'When AccountLockoutDuration is -1' {
+                $securityPolicyMock = @{
+                    'System Access' = @{ AccountLockoutDuration = -1}
+                }
+                Mock -CommandName 'Get-SecurityPolicy' -MockWith {$securityPolicyMock}
+                It 'Should return 0' {
+                    $getResult = Get-TargetResource -Name Test
+                    $getResult.Account_lockout_duration | Should Be 0
                 }
             }
         }
@@ -140,7 +151,7 @@ try
             }
         }
         Describe 'Set-TargetResource' {
-            Mock -CommandName Invoke-Secedit -MockWith {}
+            Mock -CommandName Invoke-Secedit
             
             Context 'Successfully applied account policy' {
                 Mock -CommandName Test-TargetResource -MockWith { $true }

--- a/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
+++ b/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
@@ -231,7 +231,8 @@ function Set-TargetResource
 
     if ($successResult -eq $false)
     {
-        throw "$($script:localizedData.SetFailed -f $($nonComplaintPolicies -join ','))"
+        $nonComplaintPolicies = $nonComplaintPolicies | Sort-Object
+        throw ($script:localizedData.SetFailed -f ($nonComplaintPolicies -join ','))
     }
     else
     {

--- a/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
+++ b/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
@@ -43,7 +43,8 @@ function Get-TargetResource
             $stringValue = ($currentValue -split ',')[-1]
             $resultValue = ($stringValue -replace '"').Trim()
 
-            if ($resultValue -eq -1 -and $accountPolicy -eq 'Maximum_Password_Age')
+            if ($resultValue -eq -1 -and
+                ($accountPolicy -eq 'Maximum_Password_Age' -or $accountPolicy -eq 'Account_Lockout_Duration'))
             {
                 $resultValue = 0
             }
@@ -185,7 +186,7 @@ function Set-TargetResource
             {
                 if ([String]::IsNullOrWhiteSpace($policyData.Option.String))
                 {
-                    if ($policy.Key -eq 'Maximum_Password_Age' -and $policy.Value -eq 0)
+                    if ($policy.Key -eq 'Maximum_Password_Age' -or 'Account_Lockout_Duration' -and $policy.Value -eq 0)
                     {
                         <#
                             This addresses the scenario when the desired value of Maximum_Password_Age is 0.

--- a/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
+++ b/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
@@ -43,8 +43,7 @@ function Get-TargetResource
             $stringValue = ($currentValue -split ',')[-1]
             $resultValue = ($stringValue -replace '"').Trim()
 
-            if ($resultValue -eq -1 -and
-                ($accountPolicy -eq 'Maximum_Password_Age' -or $accountPolicy -eq 'Account_Lockout_Duration'))
+            if ($resultValue -eq -1 -and $accountPolicy -in 'Maximum_Password_Age','Account_Lockout_Duration')
             {
                 $resultValue = 0
             }
@@ -186,7 +185,7 @@ function Set-TargetResource
             {
                 if ([String]::IsNullOrWhiteSpace($policyData.Option.String))
                 {
-                    if ($policy.Key -eq 'Maximum_Password_Age' -or 'Account_Lockout_Duration' -and $policy.Value -eq 0)
+                    if ($policy.Key -in 'Maximum_Password_Age','Account_Lockout_Duration' -and $policy.Value -eq 0)
                     {
                         <#
                             This addresses the scenario when the desired value of Maximum_Password_Age or

--- a/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
+++ b/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
@@ -171,7 +171,7 @@ function Set-TargetResource
             Verbose     = $false
         }
 
-        <# 
+        <#
             Define what policies are not in a desired state so we only add those policies
             that need to be changed to the INF.
          #>
@@ -189,10 +189,11 @@ function Set-TargetResource
                     if ($policy.Key -eq 'Maximum_Password_Age' -or 'Account_Lockout_Duration' -and $policy.Value -eq 0)
                     {
                         <#
-                            This addresses the scenario when the desired value of Maximum_Password_Age is 0.
-                            The INF file consumed by secedit.exe requires the value to be -1.
+                            This addresses the scenario when the desired value of Maximum_Password_Age or
+                            Account_Lockout_Duration is 0. The INF file consumed by secedit.exe requires the value to
+                            be -1.
                         #>
-                        $newValue = -1                        
+                        $newValue = -1
                     }
                     else
                     {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes being able to set the `Account_lockout_duration` property of the `AccountPolicy` resource to zero.

The `AccountPolicy` unit tests have also been improved and updated to Pester v4 format.

#### This Pull Request (PR) fixes the following issues

- Fixes #140 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/securitypolicydsc/148)
<!-- Reviewable:end -->
