### PR TITLE
Ensure that returned value includes specified name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Fixed
 
 - AccountPolicy:
+  - Ensure `Get` method returns the specified `Name` property.
   - Fix applying Account_lockout_duration to zero
     [Issue #140](https://github.com/dsccommunity/SecurityPolicyDsc/issues/140).
 

--- a/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
+++ b/source/DSCResources/MSFT_AccountPolicy/MSFT_AccountPolicy.psm1
@@ -21,7 +21,10 @@ function Get-TargetResource
         $Name
     )
 
-    $returnValue = @{}
+    $returnValue = @{
+        Name = $Name
+    }
+
     $currentSecurityPolicy = Get-SecurityPolicy -Area SECURITYPOLICY
     $accountPolicyData = Get-PolicyOptionData -FilePath $("$PSScriptRoot\AccountPolicyData.psd1").Normalize()
     $accountPolicyList = Get-PolicyOptionList -ModuleName MSFT_AccountPolicy


### PR DESCRIPTION
Prior to this commit, invoking the `AccountPolicy` resource with the `Get` method would always return `$Null` for the Name property; though this property is itself never used by the resource, integrating tools are unable to tell as the Name property is also the `Key` (as defined in the MOF) for this resource; meaning when comparing the existing state of the resource it will always cause a mismatch between the specified Name and the "actual" representation of the resource on the machine, as reported by the `Get-TargetResource` function.

This commit modifies the `Get-TargetResource` function for the AccountPolicy DSC resource to _always_ return the specified Name for the resource in order to prevent churn in secondary tools such as Puppet, Ansible, or Chef.

<!--
    Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project
    is greatly appreciated!

    Please prefix the PR title with the resource name, e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please keep the headers
    and the task list.
-->

#### Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR. Also, make sure you have updated the
    CHANGELOG.md, see the task list below. An entry in the CHANGELOG.md is mandatory for all PRs.
-->

#### This Pull Request (PR) fixes the following issues

<!--
    If this PR does not fix an open issue, replace this comment block with None. If this PR
    resolves one or more open issues, replace this comment block with a list of the issues using
    a GitHub closing keyword, e.g.:

- Fixes #123
- Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/securitypolicydsc/152)
<!-- Reviewable:end -->
