### PR TITLE
updating ci with latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - SecurityPolicyDsc:
-  - Added automatic release with a new CI pipeline
+  - Added automatic release with a new CI pipeline.
     [Issue #143](https://github.com/dsccommunity/SecurityPolicyDsc/issues/143).
 
 ### Changed

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -10,9 +10,9 @@
 
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
-    Pester                      = 'latest'
+    Pester                      = '4.10.1'
     Plaster                     = 'latest'
-    ModuleBuilder               = '1.0.0'
+    ModuleBuilder               = 'latest'
     ChangelogManagement         = 'latest'
     Sampler                     = 'latest'
     MarkdownLinkCheck           = 'latest'

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 ####################################################
 #          ModuleBuilder Configuration             #
 ####################################################
-CopyDirectories:
+CopyPaths:
   - en-US
   - DSCResources
   - Modules


### PR DESCRIPTION
This repo has no been updated with the latest ModuleBuilder changes and Pester vesion pinning to v4.
This should fix the issue raised in #152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/securitypolicydsc/153)
<!-- Reviewable:end -->
