### PR TITLE
SecurityPolicyResourceHelper: Fix for command not found error when executing secedit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 - SecurityPolicyDsc:
   - Added automatic release with a new CI pipeline.
     [Issue #143](https://github.com/dsccommunity/SecurityPolicyDsc/issues/143).
-  - Updated SecurityPolicyResourceHelper functions to use the full path to the secedit program when invoked.
-    [Issue #116](https://github.com/dsccommunity/SecurityPolicyDsc/issues/116).
 
 ### Changed
 
@@ -30,6 +28,8 @@
   - Added PowerShell Dsc Resource Help Files.
 - AccountPolicy:
   - Improved and updated unit tests to Pester v4 format.
+- Updated SecurityPolicyResourceHelper functions to use the full path to the secedit program when invoked.
+  [Issue #116](https://github.com/dsccommunity/SecurityPolicyDsc/issues/116).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - SecurityPolicyDsc:
   - Added automatic release with a new CI pipeline.
     [Issue #143](https://github.com/dsccommunity/SecurityPolicyDsc/issues/143).
+  - Updated SecurityPolicyResourceHelper functions to use the full path to the secedit program when invoked.
+    [Issue #116](https://github.com/dsccommunity/SecurityPolicyDsc/issues/116).
 
 ### Changed
 

--- a/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
+++ b/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
@@ -43,6 +43,7 @@ InModuleScope $script:subModuleName {
             { ConvertTo-LocalFriendlyName -Identity 'S-1-5-32-600' -Scope 'Set' } | Should throw
         }
     }
+
     Describe 'SecurityPolicyResourceHelper\Invoke-Secedit' {
         Mock Start-Process
 
@@ -60,6 +61,7 @@ InModuleScope $script:subModuleName {
             Assert-MockCalled -CommandName Start-Process -Exactly 1
         }
     }
+
     Describe 'SecurityPolicyResourceHelper\Get-UserRightsAssignment' {
         BeforeAll {
             $ini = "$PSScriptRoot\..\TestHelpers\TestIni.txt"
@@ -80,6 +82,7 @@ InModuleScope $script:subModuleName {
             $result.section.Key1 | Should be 'Value1'
         }
     }
+
     Describe 'SecurityPolicyResourceHelper\Test-IdentityIsNull' {
         It 'Should return true when Identity is null' {
             $IdentityIsNull = Test-IdentityIsNull -Identity $null
@@ -95,6 +98,7 @@ InModuleScope $script:subModuleName {
             $IdentityIsNull | Should Be $false
         }
     }
+
     Describe 'SecurityPolicyResourceHelper\Get-SecurityPolicy' {
         BeforeAll {
             $ini = "$PSScriptRoot\..\TestHelpers\sample.inf"
@@ -146,6 +150,7 @@ InModuleScope $script:subModuleName {
         }
 
     }
+
     Describe 'SecurityPolicyResourceHelper\Test ConvertTo-SDDLDescriptor' {
         It 'Should be BA' {
             $identity = "BUILTIN\Administrators"

--- a/source/Modules/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/source/Modules/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -97,7 +97,7 @@ function Invoke-Secedit
         $arguments = $arguments + " /overwrite /quiet"
     }
 
-    $secEditCmd = Get-Command 'secedit.exe'
+    $secEditCmd = Get-Command -Name 'secedit.exe'
 
     Write-Verbose "secedit arguments: $arguments"
     Start-Process -FilePath $secEditCmd.Path -ArgumentList $arguments -RedirectStandardOutput $seceditOutput `
@@ -140,7 +140,7 @@ function Get-SecurityPolicy
 
         Write-Debug -Message ($localizedData.EchoDebugInf -f $currentSecurityPolicyFilePath)
 
-        $secEditCmd = Get-Command 'secedit.exe'
+        $secEditCmd = Get-Command -Name 'secedit.exe'
         & $secEditCmd.Path /export /cfg $currentSecurityPolicyFilePath /areas $Area | Out-Null
     }
 

--- a/source/Modules/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/source/Modules/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -97,8 +97,10 @@ function Invoke-Secedit
         $arguments = $arguments + " /overwrite /quiet"
     }
 
+    $secEditCmd = Get-Command 'secedit.exe'
+
     Write-Verbose "secedit arguments: $arguments"
-    Start-Process -FilePath secedit.exe -ArgumentList $arguments -RedirectStandardOutput $seceditOutput `
+    Start-Process -FilePath $secEditCmd.Path -ArgumentList $arguments -RedirectStandardOutput $seceditOutput `
         -NoNewWindow -Wait
 }
 

--- a/source/Modules/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/source/Modules/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -140,7 +140,8 @@ function Get-SecurityPolicy
 
         Write-Debug -Message ($localizedData.EchoDebugInf -f $currentSecurityPolicyFilePath)
 
-        secedit.exe /export /cfg $currentSecurityPolicyFilePath /areas $Area | Out-Null
+        $secEditCmd = Get-Command 'secedit.exe'
+        & $secEditCmd.Path /export /cfg $currentSecurityPolicyFilePath /areas $Area | Out-Null
     }
 
     $policyConfiguration = @{}


### PR DESCRIPTION
#### Pull Request (PR) description

Update execution of secedit command to use full path.  Issues have been seen with new server installs where the resource generates an error about not being able to find the secedit command when invoked.

#### This Pull Request (PR) fixes the following issues

- Fixes #116

#### Task list

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/securitypolicydsc/176)
<!-- Reviewable:end -->
